### PR TITLE
Add generator overrides

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % scalacheckVersion,
-  "org.apache.avro" % "avro" % "1.8.2",
+  "org.apache.avro" % "avro" % "1.9.2",
   "com.sksamuel.avro4s" %% "avro4s-core" % "3.0.4" % Test
 )
 

--- a/src/main/scala-2.12/io/github/olib963/avrocheck/CollectionConverters.scala
+++ b/src/main/scala-2.12/io/github/olib963/avrocheck/CollectionConverters.scala
@@ -7,5 +7,6 @@ private [avrocheck] object CollectionConverters {
   def toJava[A](seq: Seq[A]): java.util.List[A] = seq.asJava
   def toJava[K, V](map: Map[K, V]): java.util.Map[K, V] = map.asJava
   def toScala[A](list: java.util.List[A]): Seq[A] = list.asScala
+  def toScalaMap[K, V](map: java.util.Map[K, V]): Map[K, V] = map.asScala.toMap
 
 }

--- a/src/main/scala-2.13/io/github/olib963/avrocheck/CollectionConverters.scala
+++ b/src/main/scala-2.13/io/github/olib963/avrocheck/CollectionConverters.scala
@@ -7,5 +7,6 @@ private [avrocheck] object CollectionConverters {
   def toJava[A](seq: Seq[A]): java.util.List[A] = seq.asJava
   def toJava[K, V](map: Map[K, V]): java.util.Map[K, V] = map.asJava
   def toScala[A](list: java.util.List[A]): Seq[A] = list.asScala.toList
+  def toScalaMap[K, V](map: java.util.Map[K, V]): Map[K, V] = map.asScala.toMap
 
 }

--- a/src/main/scala/io/github/olib963/avrocheck/AvroCheck.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/AvroCheck.scala
@@ -350,8 +350,8 @@ trait AvroCheck {
   case class SimpleError(error: String) extends AvroCheckError {
     override def errorMessages: Seq[String] = Seq(error)
   }
-  case class ComposedError(error: String, cause: AvroCheckError) extends AvroCheckError {
-    override def errorMessages: Seq[String] = error +: cause.errorMessages
+  case class ComposedError(error: String, cause: AvroCheckError, prefixErrors: Boolean = false) extends AvroCheckError {
+    override def errorMessages: Seq[String] = error +: cause.errorMessages.map("\t" + _)
   }
   case class FieldError(field: String, cause: AvroCheckError) extends AvroCheckError {
     override def errorMessages: Seq[String] = s"Could not create generator for field: $field" +: cause.errorMessages.map("\t" + _)

--- a/src/main/scala/io/github/olib963/avrocheck/AvroCheck.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/AvroCheck.scala
@@ -326,7 +326,7 @@ trait AvroCheck {
     // First byte at least is used for sign hence size - 1
     val maxUnscaled = BigInt(256).pow(size - 1) - 1
     val max = BigDecimal(maxUnscaled, decimal.getScale)
-    bigDecimal.abs.min(max) * bigDecimal.signum
+    if(max < bigDecimal.abs) max * bigDecimal.signum else bigDecimal
   }
 
   // The following functions drop extra unused precision such that a round trip of serialise -> deserialise gives the same value

--- a/src/main/scala/io/github/olib963/avrocheck/AvroCheck.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/AvroCheck.scala
@@ -29,6 +29,7 @@ trait AvroCheck {
   def selectNamedUnion(branchName: String, overrides: Overrides = NoOverrides): Overrides = SelectedUnion(branchName, overrides)
 
   def constantOverride[A](value: A): Overrides = ConstantOverride(value)
+  def generatorOverride[A](gen: Gen[A]): Overrides = GeneratorOverrides(gen)
 
   // Schema functions
   def schemaFromResource(schemaResource: String): Schema =
@@ -268,7 +269,6 @@ trait AvroCheck {
   private def eitherSequence[A, B](s: Seq[Either[A, B]]): Either[A, Seq[B]] = s.foldRight(Right(Nil): Either[A, List[B]]) {
     (e, acc) => for (xs <- acc; x <- e) yield x :: xs
   }
-
 
   private def recordGenerator(schema: Schema, configuration: Configuration, overrides: Overrides): AttemptedGen[GenericRecord] = {
     val fieldOverridesFunction: Either[AvroCheckError, String => Overrides] = overrides match {

--- a/src/main/scala/io/github/olib963/avrocheck/Configuration.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/Configuration.scala
@@ -34,7 +34,7 @@ object Configuration {
     millis <- Gen.chooseNum(Long.MinValue / 1000L, Long.MaxValue / 1000L)
   } yield Instant.ofEpochMilli(millis))
 
-  val Default = Configuration(
+  val Default: Configuration = Configuration(
     Arbitrary.arbLong.arbitrary,
     Arbitrary.arbInt.arbitrary,
     Arbitrary.arbString.arbitrary,

--- a/src/main/scala/io/github/olib963/avrocheck/Implicits.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/Implicits.scala
@@ -13,6 +13,7 @@ object Implicits {
   import scala.language.implicitConversions
 
   case class PreserialiseLogicalTypes(shouldPreserialise: Boolean)
+  implicit def preserialiseConfig(shouldPreserialise: Boolean): PreserialiseLogicalTypes = PreserialiseLogicalTypes(shouldPreserialise)
 
   implicit def configFromArbitraries(implicit longArb: Arbitrary[Long],
                                      intArb: Arbitrary[Int],
@@ -44,6 +45,7 @@ object Implicits {
     )
 
   implicit def overrideFromConstant[A](value: A): Overrides = constantOverride(value)
+  implicit def overrideFromGenerator[A](gen: Gen[A]): Overrides = generatorOverride(gen)
   // TODO name of this function
   def genFromSchemaImplicits(schema: Schema)(implicit configuration: Configuration, overrides: Overrides = NoOverrides): Gen[GenericRecord] = genFromSchema(schema, configuration, overrides)
 

--- a/src/main/scala/io/github/olib963/avrocheck/Implicits.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/Implicits.scala
@@ -3,10 +3,13 @@ package io.github.olib963.avrocheck
 import java.time.{Instant, LocalDate, LocalTime}
 import java.util.UUID
 
-import io.github.olib963.avrocheck.Overrides.{ConstantOverride, NoOverrides}
+import io.github.olib963.avrocheck
+import io.github.olib963.avrocheck.Overrides.NoOverrides
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.scalacheck.{Arbitrary, Gen}
+
+import scala.reflect.ClassTag
 
 object Implicits {
 
@@ -45,8 +48,8 @@ object Implicits {
     )
 
   implicit def overrideFromConstant[A](value: A): Overrides = constantOverride(value)
-  implicit def overrideFromGenerator[A](gen: Gen[A]): Overrides = generatorOverride(gen)
-  // TODO name of this function
-  def genFromSchemaImplicits(schema: Schema)(implicit configuration: Configuration, overrides: Overrides = NoOverrides): Gen[GenericRecord] = genFromSchema(schema, configuration, overrides)
+  implicit def overrideFromGenerator[A: ClassTag](gen: Gen[A]): Overrides = generatorOverride(gen)
+  def genFromSchemaImplicit(schema: Schema)(implicit configuration: Configuration, overrides: Overrides = NoOverrides): Gen[GenericRecord] =
+    avrocheck.genFromSchema(schema, configuration, overrides)
 
 }

--- a/src/main/scala/io/github/olib963/avrocheck/Overrides.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/Overrides.scala
@@ -12,7 +12,9 @@ private[avrocheck] object Overrides {
   case class KeyOverrides(overrides: Map[String, Overrides]) extends Overrides
   case class SelectedUnion(branchName: String, overrides: Overrides) extends Overrides
 
-  class GeneratorOverrides[A] private (val generator: Gen[A], val classTag: ClassTag[A]) extends Overrides
+  class GeneratorOverrides[A] private (val generator: Gen[A], val classTag: ClassTag[A]) extends Overrides {
+    override def toString: String = s"GeneratorOverrides(type = $classTag, generator = $generator)"
+  }
   object GeneratorOverrides {
     def apply[A](generator: Gen[A])(implicit classTag: ClassTag[A]): GeneratorOverrides[A] = new GeneratorOverrides(generator, classTag)
     def unapply(arg: GeneratorOverrides[_]): Option[(Gen[Any], ClassTag[_ <: Any])] = Some((arg.generator, arg.classTag))

--- a/src/main/scala/io/github/olib963/avrocheck/Overrides.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/Overrides.scala
@@ -1,15 +1,17 @@
 package io.github.olib963.avrocheck
 
+import org.scalacheck.Gen
+
 sealed trait Overrides
 
 object Overrides {
   object NoOverrides extends Overrides
   case class ConstantOverride(value: Any) extends Overrides
+  case class GeneratorOverrides(value: Gen[Any]) extends Overrides
   case class KeyOverrides(overrides: Map[String, Overrides]) extends Overrides
   case class SelectedUnion(branchName: String, overrides: Overrides) extends Overrides
 
   // TODO other possible overrides:
-  // - GeneratorOverride[A](gen: Gen[A]) to override the gen for one field, need to make sure it is type safe
   // - ArrayOverride: allow Gen[Int] for size, constant collection, Gen[A] to generate elements
   // - MapOverride: allow Gen[Int] for size, constant map, Gen[A] to generate values, Gen[String] generate keys
 }

--- a/src/main/scala/io/github/olib963/avrocheck/Overrides.scala
+++ b/src/main/scala/io/github/olib963/avrocheck/Overrides.scala
@@ -2,14 +2,21 @@ package io.github.olib963.avrocheck
 
 import org.scalacheck.Gen
 
+import scala.reflect.ClassTag
+
 sealed trait Overrides
 
-object Overrides {
+private[avrocheck] object Overrides {
   object NoOverrides extends Overrides
   case class ConstantOverride(value: Any) extends Overrides
-  case class GeneratorOverrides(value: Gen[Any]) extends Overrides
   case class KeyOverrides(overrides: Map[String, Overrides]) extends Overrides
   case class SelectedUnion(branchName: String, overrides: Overrides) extends Overrides
+
+  class GeneratorOverrides[A] private (val generator: Gen[A], val classTag: ClassTag[A]) extends Overrides
+  object GeneratorOverrides {
+    def apply[A](generator: Gen[A])(implicit classTag: ClassTag[A]): GeneratorOverrides[A] = new GeneratorOverrides(generator, classTag)
+    def unapply(arg: GeneratorOverrides[_]): Option[(Gen[Any], ClassTag[_ <: Any])] = Some((arg.generator, arg.classTag))
+  }
 
   // TODO other possible overrides:
   // - ArrayOverride: allow Gen[Int] for size, constant collection, Gen[A] to generate elements

--- a/src/test/scala-2.12/io/github/olib963/avrocheck/ScalaVersionSpecificOrderings.scala
+++ b/src/test/scala-2.12/io/github/olib963/avrocheck/ScalaVersionSpecificOrderings.scala
@@ -1,0 +1,5 @@
+package io.github.olib963.avrocheck
+
+object ScalaVersionSpecificOrderings {
+  // Only used in 2.13
+}

--- a/src/test/scala-2.13/io/github/olib963/avrocheck/ScalaVersionSpecificOrderings.scala
+++ b/src/test/scala-2.13/io/github/olib963/avrocheck/ScalaVersionSpecificOrderings.scala
@@ -1,0 +1,6 @@
+package io.github.olib963.avrocheck
+
+object ScalaVersionSpecificOrderings {
+  implicit val doubleOrder: Ordering[Double] = Ordering.Double.TotalOrdering
+  implicit val floatOrdering: Ordering[Float] = Ordering.Float.TotalOrdering
+}

--- a/src/test/scala/io/github/olib963/avrocheck/CompositeSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/CompositeSchemaTests.scala
@@ -3,8 +3,8 @@ package io.github.olib963.avrocheck
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.generic.{GenericData, GenericRecord}
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen.Parameters
+import org.scalacheck.Gen
+import CollectionConverters._
 
 import scala.util.Try
 
@@ -15,7 +15,6 @@ object CompositeSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
   override def tests =
     Seq(
       test("Schema based generator") {
-        // TODO should this just return the composite object anyway in an NRC rather than return a failure?
         forAll(compositeSchemaGen) { schema =>
           that("Because it should reject all composite schemas", Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]])
         }
@@ -23,93 +22,40 @@ object CompositeSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
       fieldSuite
     )
 
-  private def fieldSuite = {
-    val expectedForSeed1 = new GenericData.Record(schema)
-    expectedForSeed1.put("enum", new GenericData.EnumSymbol(schema.getField("enum").schema(), "b"))
-    expectedForSeed1.put("fixed", new GenericData.Fixed(
-      schema.getField("fixed").schema(),
-      Array[Byte](0, 99, 0, 1, 97, 127, 57, 127, 0, 97, 1, 1, 127, 127, -45)))
-    expectedForSeed1.put("longArray",
-      CollectionConverters.toJava(List(-5539706659784598441L, -1L, 3253015383694729175L, -8349649725000873569L, 1L, -9223372036854775808L, 7086352390877697882L,
-        -1025855910169801415L, 5340980081771819891L, -1L, 9223372036854775807L, -9223372036854775808L, -1494231739350021511L,
-        -9051056836655791438L, -5832904433934041295L, 2089374971598801494L, -9223372036854775808L, 9223372036854775807L, 9223372036854775807L,
-        0L, 0L, 4055968460948124786L, 1L, 0L, 1216524570094546806L, -7647139346699854323L, 1L, -1L, -3873487284825341888L,
-        9223372036854775807L, -3238205379105500491L, -7401279930943474020L, 0L, 3709083005474636613L, 1L, 315120932515649650L,
-        5501182890336406114L, -1L, -1L, 553492218871735700L, -1L, 0L, -9223372036854775808L, 7052106758320544478L, 0L, -9223372036854775808L,
-        3986519995097373636L, 8717583357824354672L, 1L, -9223372036854775808L)))
-    expectedForSeed1.put("stringMap",
-      CollectionConverters.toJava(Map(
-        "⋧䨻ꏮ኉嚳㌻厦ꦴᢴ㳆鿈꾓瘅ᰘ멪癖缑狈ᣐ끍뛠咣ꄍ鸩륃祋ᒥ矁嘶좃붡閤ჿ" -> "鑅盔ࢅΨ欚例掎酦쀳㵒囀姎閛홣죿嵓튦守熀⢚蘫ଙ멿㟂侨ႇꌊ耧黅冰咣ꔍ삝螈⿍恅䳹햩ᡬ居ꦰL쌏푠",
-        "ᵺꨌ噚훰픥嵊꠩禪␒큠ꂶ⯘埰侶捭欕纶㺟嘇担ᡧꄼᦄ雪⎳稘㚫૎땪훂ñ륊䫶䥺질蠆촟㗩哹峭܇鮶猵ؗ䱺䊙㭦笮楍৭梁祈繌哝䵲" -> "⽔鎉곡盔妭 ⾃登䎅槄勨伊ઉ଼歐悤숕Ɯ솦ɣҮ梬녷猱⮭﹉扠锕㚑巴羕틁ᚌ엙喝㉃യ磓",
-        "딆獄赩ㄗﳫ䫩ꐇ笿襃翗缁岊ꄚԷ縉䗨龼䓁⚯웝䠁뻲譕敓磃덲̤㮔䥚ꆉ힚唛뭃⸣ѵ꘽㫕淋琚诹僩鿜頀奜닠ᘭྩ闉ⱪ쁄犺吖皅" -> "ࡄ惔⛷譀ꖔ쓛矮荱듟닗栰賂駕鉖蕕䐍윶售湏뮧⬦諏ﱰ녵䛟궝뻦撣㶖ጠ㢮묿鶿룕ٷ잘",
-        "偘鎮歨거蕼쒹﹐쐁智㛳ℚ饔⧩唜⭚ퟹ꿻펃㾧耥洔⹋꿙翞쿳늴얘ĵ㏤샗詈譟褣㊺祎ᤜ⭖" -> "鋦㊘℀솅껠챸Ἡ漐⋨↡蝷ꆓᜨ彧멕౉䓙ୣ鲆툗瞞"
-      )))
+  private def isNumeric(string: String) = string.forall(Character.isDigit)
 
+  private def fieldSuite = {
     suite("Generators for records with composite fields",
       test("generating a random record with the appropriate types on each field") {
-        val gen = genFromSchema(schema)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedForSeed1)
-      },
-      test("generating a random record with implicit overrides") {
-        val expectedWithOverrides = new GenericData.Record(expectedForSeed1, true)
-        expectedWithOverrides.put("longArray", CollectionConverters.toJava(List[Long](-61, -33, -76, -84, -25, -45, -61, -57, -70, -82, -18, -95, -7, -94, -9, -66, -49, -40, -11, -3, -2, -30, -71, -87, -81, -6, -100, -9, -39, -68, -28, -32, -14, -97, -28, -75, -94, -63, -15, -27, -56, -85, -80, -49, -5, -83, -45, -12, -98, -3)))
-        expectedWithOverrides.put("stringMap", CollectionConverters.toJava(Map(
-          "lmruumoujmfeiffolfuyqpbjhkpgvdlExrOepuakjqcftkcvbldxbrYlqnccIuuSdoqmxydUwmjlkjqRffblwhvfWxl" -> "rQgetxbuefhxlfskecmkemzotvsuPguotJwnmkxnrspffmjlroxafgqvhtjIyxnuqdbUqevgyfwxubcrhgiezYifmxzclwlwls",
-          "qkTvrbabcktHcKirefNm" -> "vIpEucOuxOaxccTztggdxGodgxdeiwaNpmjgjmyseuxiuqBtudslfqYoocyctzeOoiwtCnfoAakigrdrwtcebnoftPdfxAjyfhve",
-          "WncH" -> "xzEjnoaqppyyGclvzavszuepwcysoxuixepTzpcmjeribmurpdraVojtkqXoxezjHzbizidojevlvhoWAozxiitrltcnkYmhYo",
-          "vte" -> "zcupSfpM",
-          "zcbRpIbgWfrxskb" -> "ojvpuzyrdsuhtklozyxrejClPvrbHVsZccrqssmlbepvkp",
-          "jUmontjyDplohzrFdsupjnqmhwkuztublqtzwxzugqfTVeuboqmqbijgHg" -> "wodroqbetCtnHqafdokkzzslbwXfvfaobjhkohmevbfraxikcWppdnlnsk",
-          "shapgegjetdnsdiwpgfOlktMwguycotfafbRbuva" -> "tijhlnbeqyrhaijBhudoqvvieneyodrgzykb",
-          "lxsdcqsopbykjbaaQaogzqkekptjbkfzxgmgizTnnhylwxercdneYtulamqpejy" -> "tdliryhwakwvkkzzxcKqglvutfelQjtyfnttugkucifBbenkRyzghvxvUfymtphlhweNclagnifqtlOr",
-          "fslfnlmnuatopqufeyzXuQpVldaqsQphtegpooctkkWqqSsryztjCqnbzix" -> "kauswCupqjxwpxk",
-          "qwiiWerkzmxapvfelbauqqblZcbkykkugnztiitzqdcbjlcwvkznhafsbxdnvmmozzipdbmtapzitpduwgbxvwxfqaa" -> "yqjiKoldoUpjxelwDMVkawlsjuFranuwqcplilzniriwDmsmyrofnThYceDpRcoznpThDBzcgbif",
-          "aXRbmbWcdhxfjdmodbfrdtgpkorbjuamotjxzxpfcWvcfBywdHiFndngsuwpnfChyogSUkyhjarIxRwhGrxvaMstm" -> "bkbprerfHcGikxylfzvtovpkchsbgrGotmpbMwjpCdiwPgvAvObqmDhaglq",
-          "akuysJiRqrAnpaghtwYmu" -> "grfteEuteyvyjhzxzxnmlpujyaqhcucebgbbrdnanqqxoJmbomahsfnfwfdaxgripPhZLhUiuqoysd",
-          "upnpopnuimmccWaupsfeMsrawcmurqgfbntkwchcadKafjlzxPcwodwdfhaupjnhp" -> "OnPhrzczTilq",
-          "vuqglnmapunfDjkQzmjnywnfiXAxrjyqctchqsFnzRyvxrzzYbbOegjnvsmyahflajfl" -> "rwlugpepmvtsugixiwdyctvjgdpgbwywhhfaghqaigIfiwzgzhgm",
-          "xjgXrwlnoRamqdikhueryajttpkwcfsukdwSxeddo" -> "haenhjsjpbjlicnlcvcpphecwedjwtaokzhvbmymzpzntakgzziswxUnuqafrbSvcjrnUye",
-          "xsuHeerkofkl" -> "JgosneOeIwibweqifyElgnihxVblkyaxbrcerhvnsdzbAptqRpsbnmUxmoejoiuGiqseufbkuqrfhjffzbvxmxguo",
-          "oedbKktyimzYfhlslifnh" -> "ogjcqahintRzmnrlmykurdqsdhYmTnanAkapgfIxmawjrktBvSsethqcanfxXeuymiyafrliiaetaoyju",
-          "eofmDCjffiskiaiwGtsjq" -> "cqpetdnrvdpctfkwpkkbhzigqa",
-          "piYJnihldiqxfsjkhwpkahxsyrkcmafyynyhdtvbwpreyjglQczonqvqzckewyupescoqrJmtms" -> "CuuisyueDocplwbgdXnjodyGxSvsBhejwFfThVtb",
-          "pmbluvbwQwqlequQaguedklxgekedXpdbgrpxlwqdgPnfprdbwxBlhHDzlwdjocjbnunrqqevfvtavemkatxoekvveomwjv" -> "tnyQbnyibh",
-          "WqwvsygwltldVbgmxjebottoredlorervpdzywejgoooihmznvporwutgzwWndim" -> "wcrsrmhyHVeBQsawplJajvmdnkukxhxjvatdoszasekwvjaymrtmydnytg",
-          "eugloxdInbbyljzanzkhzMylxNjzvsuggjfmsqfrkjhqsxrZJxosnhxyw" -> "zjeqsyjggvmgjlcmcqtBoosbuhChregjjbdzgltpdcjhqkwuruEoqfDVDaxPnptodncymwayj",
-          "kmbgvMgzqoyfqsehgptpxzzoylwhhQockbcGqovklluvsmlZkem" -> "RywlcmjwnpdtJdphmigwdegaVrwmpMpibwpIwlhnaCdbtuacmZwpkscovkpvetskfm",
-          "khblfkLmbrjVktqurrbwSvdiAohjdawjvgnscozcqluczbfztvkcocemiljvxpgqykVmCgndvsdziulgzxsruiTwcgacspRupu" -> "hydsQEilahcGgrzzttvfsoGMmoyEgdrwxswxdiwzufmhmADwkohazrxtnxjtcdpoLvaeUjrnoyvbgxyjfprmVgoxdcqh",
-          "pedjSregtlufhskervibxupwhqgreozpdSgyzfrMzognkxqdzfxfsSfwvqgqjgtdxryYUmuKfcJohukpzulcvtroyJrbop" -> "pjgxhueunuUxchuzmnBykjcyqodevvglmkifYirhiuBpfwiTwx",
-          "vjfwoaxjejsdxjpo" -> "lrqigpeXukqwvjreUjxodn",
-          "vjrnblk" -> "doqstmmpjavgoDtihzabffpugqgwsyuzyhkxrywqgoregtejrmlvbvpcjWJdcbzppmubylvmhgmxyxdvNiyrBpufxhkbrvwutubv",
-          "kqplgxzcddiykz" -> "kETfiuxyqldcNgsbsvyxnweJakEyyvhhobcxf",
-          "bkvlrpezhObydisgjjhaCiyilkgvqynLywZbdmiihkhfepqvwzbMagszaaylnhnywertnbmeTmhvuynuZjDbxMqfdwrtxmmzmj" -> "jaefznmpmudjayNrzozxrtiliypnxuzgpjqCrKffrhdbuyfSgoavjaleksonzzvqfzkkrogwzoShopiqXiidahpriLXvyF",
-          "ZnclkrycqrxszhynlfGemlldycaaoholkHenaeeuSqhgfcclcsxAfohvpscfgntoApNrLkysrycl" -> "nguqomrYfv",
-          "jvrbhbznnhyemrfaaotBJke" -> "swtrtkylPyGtvntidGuosmohbtPztzhoarhgjaljxfzqTiuIcnwyigMehfbrxztwHkmkGtm",
-          "rjgqmuzTunitadhgjrhyhyqibmygigihPOiwgfcfuyXrWfcraqkcU" -> "ajxevnyidphzeziScewmztqugvteaijanenydKxvhyejlqoLpqJHahrgdzPQgeQpaofiGbdoxvqcrxaeqkznolsdjyibpsxz",
-          "wyxzwbkfwomyFhhubochjdLfvdkgBjhhiioarrytemapnfiqneOcomoHptxljsgfvmgdNaaHcwggrquQliuhissdxdj" -> "oocrthottnzkcpcvaKOjchslbtrnOByQyjxypdwiyustklselwsSbmhyfyrpohcncymlsqgygsbaCgaVi",
-          "cvsbubkeyogyrmanlkbdnnnqmcsdzGeawouvroolkjawiqgmJa" -> "XogEkgccuprQbWegsjbwbncdfOxuyfhhuhgfufkgRacvkcpwrpknxSFsozawydmcsqctavdnnSBuvrmoqnOHaukYk",
-          "exoitezjMzcYqkrtptkkaLyhdypwujd" -> "uiqwaAGtmvutuxyoqDfzXvItnbdmqBsGkiicchcup",
-          "bshlvrhdsg" -> "ozsdLoytdvdxwmdmufrpaBouevrOb",
-          "tFfpxmUkezsbgobwswbijzwanshqhu" -> "lrictYfntXpboUthycaofEnhepfinbrijtszxgnurkdqenBaxVXsB",
-          "ukiuwzwbukzwvgqcfqmvxzexzisdqymllieecuwhxbexqpdqudlQodhmaghKkRxiddcepiorZqk" -> "gvblmcYlttenxobiGuRgtyqnmxsrIeuTtvk",
-          "qBqcatausFuxbOjlgxga" -> "IQuiwvyotjfjzirajbsxdqSazr",
-          "hvxostqhrhyukn" -> "xMvlmbghajLqemksdrbfhosYelvhoivntkrrpoiucpdwsIzazsgWlozebsYjnlfdamqLedhvAgwozAwxskolNlnukGjqo",
-          "bmaydniiNjosqsIaqe" -> "guovgtoeoRvmmsyevnebbuLzRwboledmcnvdcqjokreuIzqalsZsmqsdpowsejEbyxutitifhsdejsxfwcxdvthz",
-          "gfRlrzmPvlsfelbrsoobhdcrnknljegaspJxpfqmptvmaqjrtkaplzuhofpphldyzfyejlinuoiwkmaykpbUbvzMk" -> "pfmvtnnyyngqoqeuwsqrgnRascvqmkcdnJklciacf",
-          "qqtqaplpgtlinebuMcdipzclukjysaefgdaykprtGzwfaouzehc" -> "idpitdvmVyoinPufjfkfwVmbYvesdMezCyxovfwbqLupvtxfdavnwxunkhJrosmOpfxso",
-          "tixfxckggzjChatixhssllcdvkqzgkfckv" -> "gtmfpkCGotpd",
-          "wjnfcllufrgblKblmMzHcFbvoENJpipvsdazsawiylhmk" -> "hbgeteiayilzfaldzUlqugujCevVuudehgfdpmYozMKfulkwfqcVrwluoBqdwimiaqooaIwLazfrqjzbaviJgTtcniElXwrqaph",
-          "lgfjpqefzheftbzrtBsncwvivxTagtbuQdtShjKdelwtnwvkoseczrhLluQfbinpxvxwjutepu" -> "xXnQKWuMxdtzeydmcdomuuakeUdoxhaaewgeyqssscFyqjPossmziybFErlxloks",
-          "kJqbriiHobgzltKpnygWghbsjitqovddonKpqcreqerfyhxczxvHqpeo" -> "ouazprikaudfjsjtschdfdYzpmjyBsdxdnckokaubzpdlahxvnwxgocFaucmf",
-          "pkvtesrkJvmuoa" -> "qkzimkrqHl",
-          "mjvDaobdvOwhiojsyezpNukQvztbwgfoigqzhnvsmyjtyhSeqwpkaevoqhdbadvjmytnwbdGxaugfutqOcbogkCatFpwh" -> "Xzzzb",
-          "yFtfapkFujrbfq" -> "kcgfabtdwDstuluorwmeqahJpqgemxbi"
-        )))
+        val newConfig = Configuration.Default.copy(
+          stringGen = Gen.numStr,
+          longGen = Gen.negNum[Long],
+          byteGen = Gen.const[Byte](0)
+        )
+        forAll(genFromSchema(schema, configuration = newConfig)){r =>
+          val enum = Option(r.get("enum"))
+          val expectedEnums = Seq("a", "b", "c")
+          val enumAssertion = that(enum.map(_.toString).exists(expectedEnums.contains), s"Enum value ($enum) should be one of $expectedEnums")
 
-        // Changes the Map[String, String] and List[Long] generators
-        val newConfig = Configuration.Default.copy(stringGen = Gen.alphaStr, longGen = Gen.negNum[Long])
-        val gen = genFromSchema(schema, configuration = newConfig)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedWithOverrides)
+          val fixed = Option(r.get("fixed"))
+          val fifteen0Bytes = Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+          val expectedFixed = new GenericData.Fixed(schema.getField("fixed").schema(), fifteen0Bytes)
+          val fixedAssertion = that(fixed.contains(expectedFixed), s"Fixed value ($fixed) should only contain the byte 0")
+
+          val array = Option(r.get("longArray")).map(_.asInstanceOf[java.util.List[Long]]).map(toScala)
+          val arrayAssertion = that(array.exists(_.forall(_ <= 0)), s"Array value ($array) should only contain non positive longs")
+
+          val map = Option(r.get("stringMap")).map(_.asInstanceOf[java.util.Map[String, String]]).map(toScalaMap)
+          val mapAssertion = that(map.exists(_.forall{ case (key, value) => isNumeric(key) && isNumeric(value)}),
+            s"Map value ($map) should only contain strings that are numeric for both keys and values")
+
+          all(Seq(
+            that(r.getSchema, isEqualTo(schema)),
+            enumAssertion,
+            fixedAssertion,
+            arrayAssertion,
+            mapAssertion))
+        }
       },
       suite("Invalid Overrides",
         test("should not allow explicit enum symbol overrides") {
@@ -138,17 +84,17 @@ object CompositeSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
       suite("Valid Overrides",
         test("should let you select a specific enum") {
           val enumValue = "c"
+          val enumSymbol = new GenericData.EnumSymbol(schema.getField("enum").schema(), enumValue)
           val overrides = overrideKeys("enum" -> constantOverride(enumValue))
-          val gen = genFromSchema(schema, overrides = overrides)
-          val generated = gen(Parameters.default, firstSeed).get
-          that(generated.get("enum"), isEqualTo[AnyRef](new GenericData.EnumSymbol(schema.getField("enum").schema(), enumValue)))
+          forAll(genFromSchema(schema, overrides = overrides))(r =>
+            that(r.get("enum"), isEqualTo[AnyRef](enumSymbol)))
         },
         test("should let you override a fixed byte array with the correct size") {
           val bytes = Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+          val fixedBytes = new GenericData.Fixed(schema.getField("fixed").schema(), bytes)
           val overrides = overrideKeys("fixed" -> constantOverride(bytes))
-          val gen = genFromSchema(schema, overrides = overrides)
-          val generated = gen(Parameters.default, firstSeed).get
-          that(generated.get("fixed"), isEqualTo[AnyRef](new GenericData.Fixed(schema.getField("fixed").schema(), bytes)))
+          forAll(genFromSchema(schema, overrides = overrides))(r =>
+            that(r.get("fixed"), isEqualTo[AnyRef](fixedBytes)))
         }
       )
     )

--- a/src/test/scala/io/github/olib963/avrocheck/LogicalTypeTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/LogicalTypeTests.scala
@@ -7,11 +7,9 @@ import java.util.UUID
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.Schema.Type
-import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
-import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.generic.{GenericData, GenericRecord, GenericRecordBuilder => RecordBuilder}
 import org.apache.avro.{LogicalTypes, Schema}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Gen.Parameters
 
 import scala.util.Try
 
@@ -66,7 +64,7 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
           .set("decimalFixed", maxDecimalWith4Bytes)
           .set("date", date)
           .build()
-        forAll(genFromSchema(schema, configuration))(r => recordsShouldMatch(Some(r), expectedRecord))
+        forAll(genFromSchema(schema, configuration))(r => recordsShouldMatch(r, expectedRecord))
       },
       invalidSuite,
       validOverrideSuite,
@@ -144,9 +142,7 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
     suite("Constant Overrides", validConstants.map {
       case (key, value) => test(s"Should allow value $value for key $key") {
         val overrides = overrideKeys(key -> constantOverride(value))
-        val gen = genFromSchema(schema, overrides = overrides)
-        val generated = gen(Parameters.default, firstSeed).get
-        that(generated.get(key), isEqualTo[AnyRef](value))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get(key), isEqualTo[AnyRef](value)))
       }
     }),
     suite("Generator Overrides", Seq(
@@ -216,6 +212,6 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
         .set("decimalFixed", new GenericData.Fixed(fixedDecimalSchema, Array[Byte](0, -1, -1, -1)))
         .set("date", 2147483647)
         .build()
-      forAll(genFromSchema(schema, configuration))(r => recordsShouldMatch(Some(r), expectedRecord))
+      forAll(genFromSchema(schema, configuration))(r => recordsShouldMatch(r, expectedRecord))
     })
 }

--- a/src/test/scala/io/github/olib963/avrocheck/LogicalTypeTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/LogicalTypeTests.scala
@@ -171,7 +171,7 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
         forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("decimal"), hasType[BigDecimal]))
       },
       test(s"Should allow a generator override for fixed decimals") {
-        val biggerThanMaxValue = Arbitrary.arbBigDecimal.arbitrary.suchThat(_ >= maxDecimalWith4Bytes) // TODO this generator sometimes runs out of values
+        val biggerThanMaxValue = Arbitrary.arbBigDecimal.arbitrary.suchThat(_ >= 0).map(_ + maxDecimalWith4Bytes)
         val overrides = overrideKeys("decimalFixed" -> generatorOverride(biggerThanMaxValue))
         forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("decimalFixed"), isEqualTo[AnyRef](maxDecimalWith4Bytes)))
       },

--- a/src/test/scala/io/github/olib963/avrocheck/LogicalTypeTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/LogicalTypeTests.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.Schema.Type
+import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.{LogicalTypes, Schema}
 import org.scalacheck.{Arbitrary, Gen}
@@ -16,8 +17,6 @@ import scala.util.Try
 
 object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with PropertyAssertions {
   override val schemaFile = "record-with-logical-types.avsc"
-
-  private val preserialised = Configuration.Default.copy(preserialiseLogicalTypes = true)
 
   private val logicalTypeSchemas = List(
     LogicalTypes.date().addToSchema(Schema.create(Type.INT)),
@@ -33,62 +32,41 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
   override def tests =
     Seq(
       suite("Generator tests", logicalTypeSchemas.map(schema =>
-        // TODO should this just return the composite object anyway in an NRC rather than return a failure?
         test(s"Test for ${schema.getLogicalType.getName}")(
           that("Because it should reject all logical type schemas", Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]]))
       )),
       fieldSuite
     )
 
+  private val maxDecimalWith4Bytes = BigDecimal("1677.7215")
   private def fieldSuite = {
-    val expectedForSeed1 = new GenericData.Record(schema)
-    expectedForSeed1.put("uuid", UUID.fromString("aad1f498-5a65-4844-b88c-ac8b94466502"))
-    expectedForSeed1.put("timestampMillis", Instant.parse("1970-01-01T00:00:00.001Z"))
-    expectedForSeed1.put("timestampMicros", Instant.EPOCH)
-    expectedForSeed1.put("timeMicros", LocalTime.MIDNIGHT)
-    expectedForSeed1.put("decimalFixed", BigDecimal("0.0000"))
-    expectedForSeed1.put("decimal", BigDecimal("8550949123098682117.0000"))
-    expectedForSeed1.put("timeMillis", LocalTime.parse("23:59:59.999"))
-    expectedForSeed1.put("date", LocalDate.of(5881580, 7, 11))
     suite("Generators for records with logical type fields",
-      test("generating a random record") {
-        val gen = genFromSchema(schema)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedForSeed1)
-      },
-      test("generating a random record for next seed") {
-        val gen = genFromSchema(schema)
-        val expectedForSeed2 = new GenericData.Record(schema)
-        expectedForSeed2.put("uuid", UUID.fromString("42273d86-5537-4cc7-8687-dfd589210cd7"))
-        expectedForSeed2.put("timestampMillis", Instant.parse("1969-12-31T23:59:59.999Z"))
-        expectedForSeed2.put("timestampMicros", Instant.parse("+136641-10-17T05:33:17.319Z"))
-        expectedForSeed2.put("timeMicros", LocalTime.parse("23:59:59.999999"))
-        expectedForSeed2.put("decimalFixed", BigDecimal("-5.4053"))
-        expectedForSeed2.put("decimal", BigDecimal("4.3336"))
-        expectedForSeed2.put("timeMillis", LocalTime.MIDNIGHT)
-        expectedForSeed2.put("date", LocalDate.ofEpochDay(0))
-        recordsShouldMatch(gen(Parameters.default, secondSeed), expectedForSeed2)
-      },
-      test("generating a random record with implicit overrides") {
-        val expectedWithOverrides = new GenericData.Record(expectedForSeed1, false)
-        expectedWithOverrides.put("decimal", BigDecimal("-8550949123098682117.0000"))
-        // FixedDecimal is 0 so negated it's the same value
-        expectedWithOverrides.put("timeMillis", LocalTime.NOON)
-        expectedWithOverrides.put("date", LocalDate.of(2999, 12, 31))
+      test("generating a random record with constants in the configuration") {
+        val uuid = UUID.fromString("aad1f498-5a65-4844-b88c-ac8b94466502")
+        val instant = Instant.parse("1970-01-01T00:00:00.001Z")
+        val time = LocalTime.parse("23:59:59.999")
+        val decimal = BigDecimal("8550949123098682117.00")
+        val date = LocalDate.of(5881580, 7, 11)
 
-        val amTime = for {
-          nanoOfDay <- Gen.chooseNum(LocalTime.MIN.toNanoOfDay, LocalTime.NOON.toNanoOfDay)
-        } yield LocalTime.ofNanoOfDay(nanoOfDay)
+        val configuration = Configuration.Default.copy(
+          uuidGen = Gen.const(uuid),
+          localTimeGen = Gen.const(time),
+          localDateGen = Gen.const(date),
+          instantGen = Gen.const(instant),
+          bigDecimalGen = Gen.const(decimal)
+        )
 
-        val thisMillennium = for {
-          epochDay <- Gen.chooseNum(LocalDate.of(2000, 1, 1).toEpochDay, LocalDate.of(2999, 12, 31).toEpochDay)
-        } yield LocalDate.ofEpochDay(epochDay)
-
-        val negativeDecimal= Arbitrary.arbBigDecimal.arbitrary.map(_.abs.unary_-)
-
-        val newConfig = Configuration.Default.copy(localTimeGen = amTime, localDateGen = thisMillennium, bigDecimalGen = negativeDecimal)
-
-        val gen = genFromSchema(schema, configuration = newConfig)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedWithOverrides)
+        val expectedRecord = new RecordBuilder(schema)
+          .set("uuid", uuid)
+          .set("timestampMillis", instant)
+          .set("timestampMicros", instant)
+          .set("timeMicros", time)
+          .set("timeMillis", time)
+          .set("decimal", decimal)
+          .set("decimalFixed", maxDecimalWith4Bytes)
+          .set("date", date)
+          .build()
+        forAll(genFromSchema(schema, configuration))(r => recordsShouldMatch(Some(r), expectedRecord))
       },
       invalidSuite,
       validOverrideSuite,
@@ -96,7 +74,7 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
     )
   }
 
-  private val invalidOverrides = Seq(
+  private val invalidConstantOverrides = Seq(
     "uuid" -> 10,
     "uuid" -> "e22bccba-17f6-4cd0-9d7b-43a119a60c63", // Even though the string is a UUID the type is wrong
     "timestampMillis" -> false,
@@ -114,13 +92,40 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
     "date" -> "string",
     "date" -> 1234) // Uses underlying primitive
 
-  private def invalidSuite = suite("Invalid overrides", invalidOverrides.map {
-    case (key, value) =>
-      test(s"Should not allow value $value for key $key") {
-        val overrides = overrideKeys(key -> constantOverride(value))
-        that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
-      }
-  })
+  private val invalidGeneratorOverrides = Seq(
+    "uuid" -> generatorOverride(Gen.posNum[Float]),
+    "uuid" -> generatorOverride(Gen.const("e22bccba-17f6-4cd0-9d7b-43a119a60c63")), // Even though the string is a UUID the type is wrong
+    "timestampMillis" -> generatorOverride(Gen.alphaChar),
+    "timestampMillis" -> generatorOverride(Gen.posNum[Long]), // Uses underlying primitive
+    "timestampMicros" -> generatorOverride(Gen.const(null)),
+    "timestampMicros" -> generatorOverride(Gen.posNum[Long]), // Uses underlying primitive
+    "timeMicros" -> generatorOverride(Gen.alphaNumStr),
+    "timeMicros" -> generatorOverride(Gen.posNum[Long]), // Uses underlying primitive
+    "decimal" -> generatorOverride(Gen.posNum[Double]), // Not a bigdecimal
+    "decimal" -> generatorOverride(Gen.const(ByteBuffer.wrap(Array(0, 2)))), // Uses underlying primitive
+    "decimalFixed" -> generatorOverride(Gen.negNum[Int]), // Not a bigdecimal
+    "decimalFixed" -> generatorOverride(Gen.const(new GenericData.Fixed(schema.getField("decimalFixed").schema(), Array(0)))), // Uses underlying type
+    "timeMillis" -> generatorOverride(Gen.const("23:59:59.999")),
+    "timeMillis" -> generatorOverride(Gen.posNum[Long]), // Uses underlying primitive
+    "date" -> generatorOverride(Gen.alphaNumStr),
+    "date" -> generatorOverride(Gen.posNum[Long])) // Uses underlying primitive
+
+  private def invalidSuite = suite("Invalid overrides",
+    suite("Invalid constants", invalidConstantOverrides.map {
+      case (key, value) =>
+        test(s"Should not allow value $value for key $key") {
+          val overrides = overrideKeys(key -> constantOverride(value))
+          that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
+        }
+    }),
+    suite("Invalid generators", invalidGeneratorOverrides.map {
+      case (key, keyOverride) =>
+        test(s"Should not allow an invalid generator for key $key") {
+          val overrides = overrideKeys(key -> keyOverride)
+          that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
+        }
+    })
+  )
 
   private val validConstants = Seq(
     "uuid" -> UUID.fromString("e22bccba-17f6-4cd0-9d7b-43a119a60c63"),
@@ -132,50 +137,85 @@ object LogicalTypeTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
     "timeMillis" -> LocalTime.ofSecondOfDay(73656),
     "date" -> LocalDate.of(1991, 11, 17))
 
-  private def validOverrideSuite = suite("Valid overrides", validConstants.map {
-    case (key, value) => test(s"Should allow value $value for key $key") {
-      val overrides = overrideKeys(key -> constantOverride(value))
-      val gen = genFromSchema(schema, overrides = overrides)
-      val generated = gen(Parameters.default, firstSeed).get
-      that(generated.get(key), isEqualTo[AnyRef](value))
-    }
-  })
+  private val instantGenerator = Configuration.instantMicrosArb.arbitrary
+  private val localTimeGenerator = Configuration.localTimeArb.arbitrary
+
+  private def validOverrideSuite = suite("Valid overrides",
+    suite("Constant Overrides", validConstants.map {
+      case (key, value) => test(s"Should allow value $value for key $key") {
+        val overrides = overrideKeys(key -> constantOverride(value))
+        val gen = genFromSchema(schema, overrides = overrides)
+        val generated = gen(Parameters.default, firstSeed).get
+        that(generated.get(key), isEqualTo[AnyRef](value))
+      }
+    }),
+    suite("Generator Overrides", Seq(
+      test(s"Should allow a generator override for uuids") {
+        val overrides = overrideKeys("uuid" -> generatorOverride(Gen.uuid))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("uuid"), hasType[UUID]))
+      },
+      test(s"Should allow a generator override for timestampMillis") {
+        val overrides = overrideKeys("timestampMillis" -> generatorOverride(instantGenerator))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("timestampMillis"), hasType[Instant]))
+      },
+      test(s"Should allow a generator override for timestampMicros") {
+        val overrides = overrideKeys("timestampMicros" -> generatorOverride(instantGenerator))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("timestampMicros"), hasType[Instant]))
+      },
+      test(s"Should allow a generator override for timeMicros") {
+        val overrides = overrideKeys("timeMicros" -> generatorOverride(localTimeGenerator))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("timeMicros"), hasType[LocalTime]))
+      },
+      test(s"Should allow a generator override for decimal") {
+        val overrides = overrideKeys("decimal" -> generatorOverride(Arbitrary.arbBigDecimal.arbitrary))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("decimal"), hasType[BigDecimal]))
+      },
+      test(s"Should allow a generator override for fixed decimals") {
+        val biggerThanMaxValue = Arbitrary.arbBigDecimal.arbitrary.suchThat(_ >= maxDecimalWith4Bytes) // TODO this generator sometimes runs out of values
+        val overrides = overrideKeys("decimalFixed" -> generatorOverride(biggerThanMaxValue))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("decimalFixed"), isEqualTo[AnyRef](maxDecimalWith4Bytes)))
+      },
+      test(s"Should allow a generator override for timeMillis") {
+        val overrides = overrideKeys("timeMillis" -> generatorOverride(localTimeGenerator))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("timeMillis"), hasType[LocalTime]))
+      },
+      test(s"Should allow a generator override for date") {
+        val date = LocalDate.of(2020, 3, 2)
+        val overrides = overrideKeys("date" -> generatorOverride(Gen.const(date)))
+        forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("date"), isEqualTo[AnyRef](date)))
+      },
+    )))
 
   private def preserialisedSuite = suite("Pre serialising",
-    test("generating a random record") {
-      val expectedPreSerialised = new GenericData.Record(schema)
-      expectedPreSerialised.put("uuid", "aad1f498-5a65-4844-b88c-ac8b94466502")
-      expectedPreSerialised.put("timestampMillis", 1L)
-      expectedPreSerialised.put("timestampMicros", 0L)
-      expectedPreSerialised.put("timeMicros", 0L)
-      expectedPreSerialised.put("decimalFixed", new GenericData.Fixed(schema.getField("decimalFixed").schema(), Array(0, 0, 0, 0)))
-      expectedPreSerialised.put("decimal", ByteBuffer.wrap(Array[Byte](18, 27, 122, -109, 41, -31, -107, 23, -13, 80)))
-      expectedPreSerialised.put("timeMillis", 86399999)
-      expectedPreSerialised.put("date", 2147483647)
-      val gen = genFromSchema(schema, configuration = preserialised)
-      recordsShouldMatch(gen(Parameters.default, firstSeed), expectedPreSerialised)
-    },
-    test("constant overrides") {
-      val overrides = overrideKeys(
-        "uuid" -> constantOverride(UUID.fromString("e22bccba-17f6-4cd0-9d7b-43a119a60c63")),
-        "timestampMillis" -> constantOverride(Instant.ofEpochMilli(123456789)),
-        "timestampMicros" -> constantOverride(Instant.ofEpochMilli(987654321)),
-        "timeMicros" -> constantOverride(LocalTime.NOON),
-        "decimal" -> constantOverride(BigDecimal(10)),
-        "decimalFixed" -> constantOverride(BigDecimal(0.1273)),
-        "timeMillis" -> constantOverride(LocalTime.ofSecondOfDay(73656)),
-        "date" -> constantOverride(LocalDate.of(1991, 11, 17)))
+    test("generating a random record using constants in the configuration") {
+      val uuidString = "aad1f498-5a65-4844-b88c-ac8b94466502"
+      val uuid = UUID.fromString(uuidString)
+      val instant = Instant.parse("1970-01-01T00:00:00.001Z")
+      val time = LocalTime.parse("23:59:59.999")
+      val decimal = BigDecimal("8550949123098682117.00")
+      val date = LocalDate.of(5881580, 7, 11)
 
-      val expectedPreSerialised = new GenericData.Record(schema)
-      expectedPreSerialised.put("uuid", "e22bccba-17f6-4cd0-9d7b-43a119a60c63")
-      expectedPreSerialised.put("timestampMillis", 123456789L)
-      expectedPreSerialised.put("timestampMicros", 987654321000L)
-      expectedPreSerialised.put("timeMicros", 43200000000L)
-      expectedPreSerialised.put("decimalFixed", new GenericData.Fixed(schema.getField("decimalFixed").schema(), Array(0, 0, 4, -7)))
-      expectedPreSerialised.put("decimal", ByteBuffer.wrap(Array[Byte](1, -122, -96)))
-      expectedPreSerialised.put("timeMillis", 73656000)
-      expectedPreSerialised.put("date", 7990)
-      val gen = genFromSchema(schema, overrides = overrides, configuration = preserialised)
-      recordsShouldMatch(gen(Parameters.default, firstSeed), expectedPreSerialised)
+      val configuration = Configuration.Default.copy(
+        uuidGen = Gen.const(uuid),
+        localTimeGen = Gen.const(time),
+        localDateGen = Gen.const(date),
+        instantGen = Gen.const(instant),
+        bigDecimalGen = Gen.const(decimal),
+        preserialiseLogicalTypes = true
+      )
+
+      val decimalBytes = Array[Byte](18, 27, 122, -109, 41, -31, -107, 23, -13, 80)
+      val fixedDecimalSchema = schema.getField("decimalFixed").schema()
+      val expectedRecord = new RecordBuilder(schema)
+        .set("uuid", uuidString)
+        .set("timestampMillis", 1L)
+        .set("timestampMicros", 1000L)
+        .set("timeMicros", 86399999000L)
+        .set("timeMillis", 86399999)
+        .set("decimal", ByteBuffer.wrap(decimalBytes))
+        .set("decimalFixed", new GenericData.Fixed(fixedDecimalSchema, Array[Byte](0, -1, -1, -1)))
+        .set("date", 2147483647)
+        .build()
+      forAll(genFromSchema(schema, configuration))(r => recordsShouldMatch(Some(r), expectedRecord))
     })
 }

--- a/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
@@ -2,12 +2,16 @@ package io.github.olib963.avrocheck
 
 import java.nio.ByteBuffer
 
+import io.github.olib963.javatest.matchers.{ComparableMatchers, Matcher}
+import io.github.olib963.javatest.{Assertion, AssertionResult}
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.generic.GenericRecord
 import org.scalacheck.{Arbitrary, Gen}
 import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
+
 import scala.util.Try
+import ScalaVersionSpecificOrderings._
 
 object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with PropertyAssertions {
   override val schemaFile = "record-with-primitives.avsc"
@@ -15,7 +19,6 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
   override def tests =
     Seq(
       test("Schema based generator") {
-        // TODO should this just return the primitive object anyway in an NRC rather than return a failure?
         forAll(primitiveTypeSchemaGen) { schema =>
           that("Because it should reject all primitive schemas", Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]])
         }
@@ -72,7 +75,7 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
     ("double", generatorOverride(Gen.posNum[Int])),
     ("float", generatorOverride(Gen.posNum[Int])),
     ("long", generatorOverride(Gen.posNum[Int])),
-    ("bytes", generatorOverride(Gen.posNum[Int])),
+    ("bytes", generatorOverride(Gen.const(Array[String]("Hello", "World")))),
     ("string", generatorOverride(Gen.posNum[Int])),
     ("int", generatorOverride(Gen.alphaLowerStr))
   )
@@ -81,22 +84,21 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
     val missingFieldTest = test("you cannot override a key that doesn't exist") {
       that(Try(genFromSchema(schema, overrides = overrideKeys("foo" -> constantOverride("bar")))), isFailure[Gen[GenericRecord]])
     }
-    val constantTests = invalidConstants.map {
+    val constantTests = suite("Invalid constant overrides", invalidConstants.map {
       case (key, value) =>
         test(s"Overriding schema field $key with $value") {
           val overrides = overrideKeys(key -> constantOverride(value))
           that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
         }
-    }
-    val generatorTests = invalidGenerators.map {
+    })
+    val generatorTests = suite("Invalid generator overrides", invalidGenerators.map {
       case (key, o) =>
         test(s"Cannot override schema field $key with a generator of the wrong type") {
           val overrides = overrideKeys(key -> o)
-          that(Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]])
-          pending()
+          that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
         }
-    }
-    suite("Invalid override types", missingFieldTest +: (constantTests ++ generatorTests))
+    })
+    suite("Invalid override types", Seq(missingFieldTest, constantTests, generatorTests))
   }
 
   private val validConstants = Seq(
@@ -107,6 +109,15 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
     ("string", "string", constantOverride("string")),
     ("int", 40, constantOverride(40)),
     ("null", null, constantOverride(null)))
+
+  // TODO move to JT?
+  private def fail(reason: String): Assertion = () => AssertionResult.failure(reason)
+
+  private def isBetween[A](min: A, max: A)(implicit ordering: Ordering[A]): Matcher[A] =
+    matcher(s"be between $min and $max")(a => ordering.gteq(a, min) && ordering.lteq(a,  max))
+
+  private val alphaNumChars = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).toSet
+  private val isAlphanumeric: Matcher[String] = matcher("be alphanumeric")(_.forall(alphaNumChars.contains))
 
   private def validOverrideSuites = {
     // Because byte arrays are wrapped we cannot use same method of testing
@@ -126,36 +137,49 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
       suite("Valid generator overrides",
         test(s"Should allow a generator override for booleans") {
           val overrides = overrideKeys("boolean" -> generatorOverride(Arbitrary.arbBool.arbitrary))
-          forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("boolean"), hasType[Boolean]))
+          forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("boolean"), hasType[java.lang.Boolean]))
         },
-        // TODO test the values are between limits
         test(s"Should allow a generator override for doubles") {
           val overrides = overrideKeys("double" -> generatorOverride(Gen.chooseNum[Double](10, 20)))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+          forAll(genFromSchema(schema, overrides = overrides))(r => r.get("double") match {
+            case d: java.lang.Double => that(Double.unbox(d), isBetween(10d, 20d))
+            case other => fail(s"Expected $other to be a double")
+          })
         },
         test(s"Should allow a generator override for floats") {
           val overrides = overrideKeys("float" -> generatorOverride(Gen.chooseNum[Float](-20, -10)))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+          forAll(genFromSchema(schema, overrides = overrides))(r => r.get("float") match {
+            case f: java.lang.Float => that(Float.unbox(f), isBetween(-20f, -10f))
+            case other => fail(s"Expected $other to be a float")
+          })
         },
         test(s"Should allow a generator override for longs") {
           val overrides = overrideKeys("long" -> generatorOverride(Gen.negNum[Long]))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+          forAll(genFromSchema(schema, overrides = overrides))(r => r.get("long") match {
+            case l: java.lang.Long => that(l, ComparableMatchers.isLessThan(Long.box(0)))
+            case other => fail(s"Expected $other to be a long")
+          })
         },
         test(s"Should allow a generator override for strings") {
           val overrides = overrideKeys("string" -> generatorOverride(Gen.alphaLowerStr))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+          forAll(genFromSchema(schema, overrides = overrides))(r => r.get("string") match {
+            case s: String => that(s, isAlphanumeric)
+            case other => fail(s"Expected $other to be a string")
+          })
         },
         test(s"Should allow a generator override for byte arrays") {
           val overrides = overrideKeys("bytes" -> generatorOverride(Gen.containerOfN[Array, Byte](4, Arbitrary.arbByte.arbitrary)))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+          forAll(genFromSchema(schema, overrides = overrides))(r => r.get("bytes") match {
+            case b: ByteBuffer => that(b.array().toIterable, hasSize[Byte](4))
+            case other => fail(s"Expected $other to be a byte buffer")
+          })
         },
         test(s"Should allow a generator override for ints") {
           val overrides = overrideKeys("int" -> generatorOverride(Gen.posNum[Int]))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
-        },
-        test(s"Should allow a generator override for null") {
-          val overrides = overrideKeys("null" -> generatorOverride(Gen.const(null)))
-          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+          forAll(genFromSchema(schema, overrides = overrides))(r => r.get("int") match {
+            case i: java.lang.Integer => that(i, ComparableMatchers.isGreaterThan(Int.box(0)))
+            case other => fail(s"Expected $other to be an int")
+          })
         }
       )
     )

--- a/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
@@ -47,7 +47,7 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
             .build()
           // TODO how to check bytes without override?
           forAll(genFromSchema(schema, configuration, overrides = overrideKeys("bytes" -> constantOverride(bytes))))(
-            r => recordsShouldMatch(Some(r), expectedRecord))
+            r => recordsShouldMatch(r, expectedRecord))
         }, invalidOverrideSuite) ++ validOverrideSuites
       )
     )

--- a/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
@@ -7,6 +7,7 @@ import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.scalacheck.Gen.Parameters
 import org.scalacheck.{Arbitrary, Gen}
+import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
 
 import scala.util.Try
 
@@ -21,8 +22,30 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
           that("Because it should reject all primitive schemas", Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]])
         }
       },
-      primitiveFieldSuite
+      primitiveFieldSuite,
+      fieldSuiteNew
     )
+
+  def fieldSuiteNew = {
+    suite("Generators for records with primitive fields",
+      test("generating a random record with constants in the configuration") {
+        val expectedRecord = new RecordBuilder(schema)
+          .set("boolean", true)
+          .set("double", 3.14159265358979)
+          .set("float", 0.5f)
+          .set("long", 1L)
+          .set("bytes", ByteBuffer.wrap(Array[Byte](1, 2, 3, 4)))
+          .set("string", "hello")
+          .set("int", 8)
+          .set("null", null)
+          .build()
+        forAll(genFromSchema(schema))(r => recordsShouldMatch(Some(r), expectedRecord))
+      },
+      test("Generating a random record with constant overrides")(pending()),
+      test("Generating a random record with generator overrides")(pending()),
+      invalidOverrideSuite,
+    )
+  }
 
   private def primitiveFieldSuite = {
     val expectedForSeed1 = new GenericData.Record(schema)

--- a/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/PrimitiveSchemaTests.scala
@@ -4,11 +4,9 @@ import java.nio.ByteBuffer
 
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
-import org.apache.avro.generic.{GenericData, GenericRecord}
-import org.scalacheck.Gen.Parameters
+import org.apache.avro.generic.GenericRecord
 import org.scalacheck.{Arbitrary, Gen}
 import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
-
 import scala.util.Try
 
 object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with PropertyAssertions {
@@ -22,80 +20,36 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
           that("Because it should reject all primitive schemas", Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]])
         }
       },
-      primitiveFieldSuite,
-      fieldSuiteNew
+      suite("Generators for records with primitive fields",
+        Seq(test("generating a random record with constants in the configuration") {
+          val pi = 3.14159265358979
+          val configuration = Configuration.Default.copy(
+            booleanGen = Gen.const(true),
+            doubleGen = Gen.const(pi),
+            floatGen = Gen.const(0.5f),
+            longGen = Gen.const(1L),
+            stringGen = Gen.const("hello"),
+            intGen = Gen.const(8)
+          )
+          val bytes = Array[Byte](1, 2, 3, 4)
+          val expectedRecord = new RecordBuilder(schema)
+            .set("boolean", true)
+            .set("double", pi)
+            .set("float", 0.5f)
+            .set("long", 1L)
+            .set("bytes", ByteBuffer.wrap(bytes))
+            .set("string", "hello")
+            .set("int", 8)
+            .set("null", null)
+            .build()
+          // TODO how to check bytes without override?
+          forAll(genFromSchema(schema, configuration, overrides = overrideKeys("bytes" -> constantOverride(bytes))))(
+            r => recordsShouldMatch(Some(r), expectedRecord))
+        }, invalidOverrideSuite) ++ validOverrideSuites
+      )
     )
 
-  def fieldSuiteNew = {
-    suite("Generators for records with primitive fields",
-      test("generating a random record with constants in the configuration") {
-        val expectedRecord = new RecordBuilder(schema)
-          .set("boolean", true)
-          .set("double", 3.14159265358979)
-          .set("float", 0.5f)
-          .set("long", 1L)
-          .set("bytes", ByteBuffer.wrap(Array[Byte](1, 2, 3, 4)))
-          .set("string", "hello")
-          .set("int", 8)
-          .set("null", null)
-          .build()
-        forAll(genFromSchema(schema))(r => recordsShouldMatch(Some(r), expectedRecord))
-      },
-      test("Generating a random record with constant overrides")(pending()),
-      test("Generating a random record with generator overrides")(pending()),
-      invalidOverrideSuite,
-    )
-  }
-
-  private def primitiveFieldSuite = {
-    val expectedForSeed1 = new GenericData.Record(schema)
-    expectedForSeed1.put("boolean", true)
-    expectedForSeed1.put("double", 3.9481521047910786E247)
-    expectedForSeed1.put("float", 2.95789737E12f)
-    expectedForSeed1.put("long", -1556412554917007977L)
-    expectedForSeed1.put("bytes", ByteBuffer.wrap(Array[Byte](127, 127, 0, 97, 1, 1, 127, 127, -45, -5, -68, -41, -97, 1, -128, 90, 57, 115, -1, 127, -128, 121, -78, 49, 86, -128, 127, 127, 0, 0, 114, 1, 0, 118, 13, 1, -1, 64, 127, -75, -100, 0, 69, 1, 114, 98, -1, -1, -108, -1, 0, -128, -34, 0, -128, -60, 112, 1, -128, 0, 127, -25, 127, 1, -18, -128, -105, 1, 1, 127, -90)))
-    expectedForSeed1.put("string", "걤鉖ⲏ컯ᢉ᭽奚䮤檏ᯆᐩ䶏쪂椗⽘腢片髐୽譋⒵랼⽄Ꭽ鑅盔ࢅΨ欚例掎酦쀳㵒囀姎閛홣죿嵓튦守熀⢚蘫ଙ멿㟂侨ႇꌊ耧黅冰")
-    expectedForSeed1.put("int", 0)
-    expectedForSeed1.put("null", null)
-
-    suite("Generators for records with primitive fields",
-      test("generating a random record") {
-        val gen = genFromSchema(schema)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedForSeed1)
-      },
-      test("generating a random record for next seed") {
-        val gen = genFromSchema(schema)
-        val expectedForSeed2 = new GenericData.Record(schema)
-        expectedForSeed2.put("boolean", false)
-        expectedForSeed2.put("double", -7.742894263224504E163)
-        expectedForSeed2.put("float", -1.7298706E37f)
-        expectedForSeed2.put("long", -1L)
-        expectedForSeed2.put("bytes", ByteBuffer.wrap(Array[Byte](-29, -92, 57, 1, 0, -1, -128, 0, -1, 1, -99, 14, 1, -20, 75, -1, 127, -128, -27, 126)))
-        expectedForSeed2.put("string", "櫯\u200E鼰놊팿ᒲᬩ섨膫ӿ槎糏獺엠㟃環羞跙⩏앛笋䱸畍ꛫ㮏䚓⬇ﳛ崏칾㰌┎径騆籘ꚿⓕ㝨ꟼ噧暜஬ᦘ墢歘⹣༗伒Ո᠅")
-        expectedForSeed2.put("int", -1038086538)
-        expectedForSeed2.put("null", null)
-
-        recordsShouldMatch(gen(Parameters.default, secondSeed), expectedForSeed2)
-      },
-      test("generating a random record with implicit overrides") {
-        // This will override just the int and string fields
-        // PLEASE NOTE: The string and int fields are last in the schema, this is because the random value of each field effects the seed of the next field,
-        // this means if we moved, for example, 'long' to be after 'string' and 'int' it's value would change since the previous input would have changed
-        val expectedWithOverrides = new GenericData.Record(expectedForSeed1, true)
-        expectedWithOverrides.put("string", "mutblrcyxQhLibemuhatxpsgkdjZksfaqdqqXmuihrHvbcyeeZxfqohonvi")
-        expectedWithOverrides.put("int", -78)
-
-        val newConfig = Configuration.Default.copy(stringGen = Gen.alphaStr, intGen = Gen.negNum[Int])
-
-        val gen = genFromSchema(schema, configuration = newConfig)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedWithOverrides)
-      },
-      invalidOverrideSuite,
-      validOverrideSuite
-    )
-  }
-
-  private val invalids = Seq(
+  private val invalidConstants = Seq(
     "null" -> "foo",
     "boolean" -> 10,
     "double" -> "string",
@@ -110,48 +64,101 @@ object PrimitiveSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
     "bytes" -> Array[String]("hello"),
     "string" -> 0.0,
     "int" -> "string",
-    "int" -> Long.MaxValue)
+    "int" -> Long.MaxValue).map { case (key, value) => (key, constantOverride(value)) }
+
+  private val invalidGenerators = Seq(
+    ("null", generatorOverride(Gen.alphaLowerStr)),
+    ("boolean", generatorOverride(Gen.posNum[Int])),
+    ("double", generatorOverride(Gen.posNum[Int])),
+    ("float", generatorOverride(Gen.posNum[Int])),
+    ("long", generatorOverride(Gen.posNum[Int])),
+    ("bytes", generatorOverride(Gen.posNum[Int])),
+    ("string", generatorOverride(Gen.posNum[Int])),
+    ("int", generatorOverride(Gen.alphaLowerStr))
+  )
 
   private def invalidOverrideSuite = {
     val missingFieldTest = test("you cannot override a key that doesn't exist") {
       that(Try(genFromSchema(schema, overrides = overrideKeys("foo" -> constantOverride("bar")))), isFailure[Gen[GenericRecord]])
     }
-    suite("Invalid override types", missingFieldTest +: invalids.map {
+    val constantTests = invalidConstants.map {
       case (key, value) =>
         test(s"Overriding schema field $key with $value") {
           val overrides = overrideKeys(key -> constantOverride(value))
           that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
         }
-    })
+    }
+    val generatorTests = invalidGenerators.map {
+      case (key, o) =>
+        test(s"Cannot override schema field $key with a generator of the wrong type") {
+          val overrides = overrideKeys(key -> o)
+          that(Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]])
+          pending()
+        }
+    }
+    suite("Invalid override types", missingFieldTest +: (constantTests ++ generatorTests))
   }
 
   private val validConstants = Seq(
-    "boolean" -> false,
-    "double" -> 2.0,
-    "float" -> 1.0f,
-    "long" -> 12L,
-    "string" -> "string",
-    "int" -> 40,
-    "null" -> null)
+    ("boolean", false, constantOverride(false)),
+    ("double", 2.0, constantOverride(2.0)),
+    ("float", 1.0f, constantOverride(1.0f)),
+    ("long", 12L, constantOverride(12L)),
+    ("string", "string", constantOverride("string")),
+    ("int", 40, constantOverride(40)),
+    ("null", null, constantOverride(null)))
 
-  private def validOverrideSuite = {
+  private def validOverrideSuites = {
     // Because byte arrays are wrapped we cannot use same method of testing
-    val byteArrayTest = test(s"You can override byte arrays") {
+    val byteArrayTest = test(s"You can override byte arrays with a constant") {
       val bytes = Array[Byte](0, 1, 2)
       val overrides = overrideKeys("bytes" -> constantOverride(bytes))
-      val gen = genFromSchema(schema, overrides = overrides)
-      val generated = gen(Parameters.default, firstSeed).get
-      that(generated.get("bytes"), isEqualTo[Object](ByteBuffer.wrap(bytes)))
+      forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("bytes"), isEqualTo[Object](ByteBuffer.wrap(bytes))))
     }
-    suite("Valid constant overrides", byteArrayTest +: validConstants.map {
-      case (key, value) =>
-        test(s"Should allow value $value for key $key") {
-          val overrides = overrideKeys(key -> constantOverride(value))
-          val gen = genFromSchema(schema, overrides = overrides)
-          val generated = gen(Parameters.default, firstSeed).get
-          that(generated.get(key), isEqualTo(value))
+    Seq(
+      suite("Valid constant overrides", byteArrayTest +: validConstants.map {
+        case (key, value, o) =>
+          test(s"Should allow value $value for key $key") {
+            val overrides = overrideKeys(key -> o)
+            forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get(key), isEqualTo(value)))
+          }
+      }),
+      suite("Valid generator overrides",
+        test(s"Should allow a generator override for booleans") {
+          val overrides = overrideKeys("boolean" -> generatorOverride(Arbitrary.arbBool.arbitrary))
+          forAll(genFromSchema(schema, overrides = overrides))(r => that(r.get("boolean"), hasType[Boolean]))
+        },
+        // TODO test the values are between limits
+        test(s"Should allow a generator override for doubles") {
+          val overrides = overrideKeys("double" -> generatorOverride(Gen.chooseNum[Double](10, 20)))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+        },
+        test(s"Should allow a generator override for floats") {
+          val overrides = overrideKeys("float" -> generatorOverride(Gen.chooseNum[Float](-20, -10)))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+        },
+        test(s"Should allow a generator override for longs") {
+          val overrides = overrideKeys("long" -> generatorOverride(Gen.negNum[Long]))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+        },
+        test(s"Should allow a generator override for strings") {
+          val overrides = overrideKeys("string" -> generatorOverride(Gen.alphaLowerStr))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+        },
+        test(s"Should allow a generator override for byte arrays") {
+          val overrides = overrideKeys("bytes" -> generatorOverride(Gen.containerOfN[Array, Byte](4, Arbitrary.arbByte.arbitrary)))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+        },
+        test(s"Should allow a generator override for ints") {
+          val overrides = overrideKeys("int" -> generatorOverride(Gen.posNum[Int]))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
+        },
+        test(s"Should allow a generator override for null") {
+          val overrides = overrideKeys("null" -> generatorOverride(Gen.const(null)))
+          forAll(genFromSchema(schema, overrides = overrides))(r => pending())
         }
-    })
+      )
+    )
   }
 
 }

--- a/src/test/scala/io/github/olib963/avrocheck/RecordWithUnionTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/RecordWithUnionTests.scala
@@ -2,8 +2,8 @@ package io.github.olib963.avrocheck
 
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
-import org.apache.avro.generic.{GenericData, GenericRecord}
-import org.scalacheck.{Arbitrary, Gen}
+import org.apache.avro.generic.{GenericData, GenericRecord, GenericRecordBuilder => RecordBuilder}
+import org.scalacheck.Gen
 import org.scalacheck.Gen.Parameters
 
 import scala.util.Try
@@ -12,30 +12,39 @@ object RecordWithUnionTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
   override val schemaFile: String = "record-with-unions.avsc"
 
   override def tests = {
-    val expectedForSeed1 = new GenericData.Record(schema)
-    expectedForSeed1.put("nullableInt", null)
-    expectedForSeed1.put("stringOrLong", "䬒갛햗鸹쳤⹡ᕫ雓ꏻꂼ濗榟秆齚⭳풺亮䱇Ⅽ둲䉄彶瘍⩠偀閣훫ꫲ썅髆짹젊틥ﮎ赂ዞ㯄ᥰ뚀ﭙ⋧䨻ꏮ኉嚳㌻厦ꦴᢴ㳆鿈꾓瘅ᰘ멪癖缑狈ᣐ끍뛠咣ꄍ鸩륃祋ᒥ矁嘶좃붡閤ჿ㸈䓾䮨霡㖐菾뀸분㌵ꆸᙣ蹙랑퟿㛉஘굃ﯾ")
     Seq(
       test("generating a random record") {
-        val gen = genFromSchema(schema)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedForSeed1)
-      },
-      test("generating a random record for next seed") {
-        val gen = genFromSchema(schema)
-        val expectedForSeed2 = new GenericData.Record(schema)
-        expectedForSeed2.put("nullableInt", 2093140340)
-        expectedForSeed2.put("stringOrLong", "㧁ම㳣群尹つ沨攺酻⎻忬契⼳쎒ඞ櫯‎鼰놊팿ᒲ")
+        val configuration = Configuration.Default.copy(
+          stringGen = Gen.const("hello"),
+          intGen = Gen.const(8),
+          longGen = Gen.const(1234L)
+        )
 
-        recordsShouldMatch(gen(Parameters.default, secondSeed), expectedForSeed2)
-      },
-      test("generating a random record with implicit overrides") {
-        val expectedWithOverrides = new GenericData.Record(expectedForSeed1, true)
-        expectedWithOverrides.put("nullableInt", null)
-        expectedWithOverrides.put("stringOrLong", "}^#HyNhXb\"*sZ<b]>2U8c`lu\\LiC#\"u-0gevpj1A*$2t`uD!|Jd&sTWg'HF`% SCw%P;6s(_4o`yBWk~hC^(JR,:ir}fOXuuXxK")
-        val newConfig = Configuration.Default.copy(stringGen = Gen.asciiPrintableStr)
+        val nullAndString = new RecordBuilder(schema)
+          .set("nullableInt", null)
+          .set("stringOrLong", "hello")
+          .build()
 
-        val gen = genFromSchema(schema, configuration = newConfig)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedWithOverrides)
+        val nullAndLong = new RecordBuilder(schema)
+          .set("nullableInt", null)
+          .set("stringOrLong", 1234L)
+          .build()
+
+        val intAndString = new RecordBuilder(schema)
+          .set("nullableInt", 8)
+          .set("stringOrLong", "hello")
+          .build()
+
+        val nintAndLong = new RecordBuilder(schema)
+          .set("nullableInt", 8)
+          .set("stringOrLong", 1234L)
+          .build()
+        forAll(genFromSchema(schema, configuration)){r =>
+          recordsShouldMatch(Some(r), nullAndString)
+            .or(recordsShouldMatch(Some(r), nullAndLong))
+            .or(recordsShouldMatch(Some(r), intAndString))
+            .or(recordsShouldMatch(Some(r), nintAndLong))
+        }
       },
       test("should not let you select a type that doesn't exist in the union") {
         val intAsString = {
@@ -51,12 +60,12 @@ object RecordWithUnionTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
       test("Valid overrides, selecting a value for one branch of the union"){
         val overrides = overrideKeys("nullableInt" -> constantOverride(12), "stringOrLong" -> constantOverride(123L))
 
-        val expectedUnionSelected = new GenericData.Record(schema)
-        expectedUnionSelected.put("nullableInt", 12)
-        expectedUnionSelected.put("stringOrLong", 123L)
+        val expectedUnionSelected = new RecordBuilder(schema)
+          .set("nullableInt", 12)
+          .set("stringOrLong", 123L)
+          .build()
 
-        val gen = genFromSchema(schema, overrides = overrides)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedUnionSelected)
+        forAll(genFromSchema(schema, overrides = overrides))(r => recordsShouldMatch(Some(r), expectedUnionSelected))
       }
     )
   }

--- a/src/test/scala/io/github/olib963/avrocheck/RecordWithUnionTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/RecordWithUnionTests.scala
@@ -2,9 +2,8 @@ package io.github.olib963.avrocheck
 
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
-import org.apache.avro.generic.{GenericData, GenericRecord, GenericRecordBuilder => RecordBuilder}
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder => RecordBuilder}
 import org.scalacheck.Gen
-import org.scalacheck.Gen.Parameters
 
 import scala.util.Try
 
@@ -40,10 +39,10 @@ object RecordWithUnionTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
           .set("stringOrLong", 1234L)
           .build()
         forAll(genFromSchema(schema, configuration)){r =>
-          recordsShouldMatch(Some(r), nullAndString)
-            .or(recordsShouldMatch(Some(r), nullAndLong))
-            .or(recordsShouldMatch(Some(r), intAndString))
-            .or(recordsShouldMatch(Some(r), nintAndLong))
+          recordsShouldMatch(r, nullAndString)
+            .or(recordsShouldMatch(r, nullAndLong))
+            .or(recordsShouldMatch(r, intAndString))
+            .or(recordsShouldMatch(r, nintAndLong))
         }
       },
       test("should not let you select a type that doesn't exist in the union") {
@@ -65,7 +64,7 @@ object RecordWithUnionTests extends SchemaGeneratorSuite with AllJavaTestSyntax 
           .set("stringOrLong", 123L)
           .build()
 
-        forAll(genFromSchema(schema, overrides = overrides))(r => recordsShouldMatch(Some(r), expectedUnionSelected))
+        forAll(genFromSchema(schema, overrides = overrides))(r => recordsShouldMatch(r, expectedUnionSelected))
       }
     )
   }

--- a/src/test/scala/io/github/olib963/avrocheck/SchemaGeneratorSuite.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/SchemaGeneratorSuite.scala
@@ -1,12 +1,11 @@
 package io.github.olib963.avrocheck
 
-import io.github.olib963.javatest.{Assertion, AssertionResult}
+import io.github.olib963.javatest.Assertion
 import io.github.olib963.javatest_scala.Suite
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type
 import org.apache.avro.generic.GenericRecord
 import org.scalacheck.Gen
-import org.scalacheck.rng.Seed
 
 // Define a few utilities for creating Specs that check the generated output from schemas with fixed specs
 trait SchemaGeneratorSuite extends Suite with AvroCheck {
@@ -26,17 +25,10 @@ trait SchemaGeneratorSuite extends Suite with AvroCheck {
   val schemaFile: String
   lazy val schema = schemaFromResource(schemaFile)
 
-  // TODO delete seeds
-  val firstSeed = Seed(10)
-  val secondSeed = Seed(1234567890)
-
   import CollectionConverters.toScala
   import io.github.olib963.javatest_scala._
 
-  // TODO remove option
-  def recordsShouldMatch(generated: Option[GenericRecord], expected: GenericRecord, expectedSchema: Schema = schema): Assertion = generated match {
-    case None => () => AssertionResult.failure("No record was generated")
-    case Some(record) =>
+  def recordsShouldMatch(record: GenericRecord, expected: GenericRecord, expectedSchema: Schema = schema): Assertion = {
       val fieldAssertions = toScala(expectedSchema.getFields).map(_.name()).map(field =>
         that(s"The field $field should match", record.get(field), isEqualTo(expected.get(field))))
       all(that("The schema should be the expected one", record.getSchema, isEqualTo(expectedSchema)) +: fieldAssertions.toList)

--- a/src/test/scala/io/github/olib963/avrocheck/SchemaGeneratorSuite.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/SchemaGeneratorSuite.scala
@@ -26,6 +26,7 @@ trait SchemaGeneratorSuite extends Suite with AvroCheck {
   val schemaFile: String
   lazy val schema = schemaFromResource(schemaFile)
 
+  // TODO delete seeds
   val firstSeed = Seed(10)
   val secondSeed = Seed(1234567890)
 
@@ -34,7 +35,7 @@ trait SchemaGeneratorSuite extends Suite with AvroCheck {
 
   // TODO remove option
   def recordsShouldMatch(generated: Option[GenericRecord], expected: GenericRecord, expectedSchema: Schema = schema): Assertion = generated match {
-    case None => () => AssertionResult.failure("No record was generated") // TODO more explicit failure function
+    case None => () => AssertionResult.failure("No record was generated")
     case Some(record) =>
       val fieldAssertions = toScala(expectedSchema.getFields).map(_.name()).map(field =>
         that(s"The field $field should match", record.get(field), isEqualTo(expected.get(field))))

--- a/src/test/scala/io/github/olib963/avrocheck/SchemaGeneratorSuite.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/SchemaGeneratorSuite.scala
@@ -32,6 +32,7 @@ trait SchemaGeneratorSuite extends Suite with AvroCheck {
   import CollectionConverters.toScala
   import io.github.olib963.javatest_scala._
 
+  // TODO remove option
   def recordsShouldMatch(generated: Option[GenericRecord], expected: GenericRecord, expectedSchema: Schema = schema): Assertion = generated match {
     case None => () => AssertionResult.failure("No record was generated") // TODO more explicit failure function
     case Some(record) =>

--- a/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
@@ -60,8 +60,8 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
           val overrides = selectNamedUnion("Baz")
           that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
         },
-        test("should not let you set override keys for a union") {
-          val overrides = overrideKeys("int" -> constantOverride(2))
+        test("should not let you set an invalid override for a union") {
+          val overrides = constantOverride(2)
           that(Try(genFromSchema(schema, overrides = overrides)), isFailure[Gen[GenericRecord]])
         }
       ),

--- a/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
@@ -3,10 +3,8 @@ package io.github.olib963.avrocheck
 import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.Schema
-import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder => RecordBuilder}
 import org.scalacheck.Gen
-import org.scalacheck.Gen.Parameters
-import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
 
 import scala.util.Try
 

--- a/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
@@ -4,8 +4,9 @@ import io.github.olib963.javatest_scala.AllJavaTestSyntax
 import io.github.olib963.javatest_scala.scalacheck.PropertyAssertions
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord}
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen
 import org.scalacheck.Gen.Parameters
+import org.apache.avro.generic.{GenericRecordBuilder => RecordBuilder}
 
 import scala.util.Try
 
@@ -18,7 +19,6 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
       set <- Gen.containerOf[Set, Schema](invalidSubType) // remove duplicates
     } yield Schema.createUnion(CollectionConverters.toJava(set.toList))
     Seq(
-      // TODO should this just return the object anyway in an NRC rather than return a failure?
       test(s"Generator tests")(forAll(invalidUnionGen)(schema =>
         that("Because it should reject all logical type schemas", Try(genFromSchema(schema)), isFailure[Gen[GenericRecord]]))),
       unionRecordsSuite
@@ -29,31 +29,26 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
     val fooBranch = schema.getTypes.get(0)
     val barBranch = schema.getTypes.get(1)
 
-    val expectedForSeed1 = new GenericData.Record(fooBranch)
-    expectedForSeed1.put("boolean", true)
-    expectedForSeed1.put("int", -931653021)
     suite("Generating a union of records",
-      test("generating a random record") {
-        val gen = genFromSchema(schema)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedForSeed1, expectedSchema = fooBranch)
-      },
-      test("generating a random record for next seed") {
-        val gen = genFromSchema(schema)
-        val expectedForSeed2 = new GenericData.Record(barBranch)
-        expectedForSeed2.put("double", -7.742894263224504E163)
-        expectedForSeed2.put("string", "㧁ම㳣群尹つ沨攺酻⎻忬契⼳쎒ඞ櫯‎鼰놊팿ᒲ")
-        expectedForSeed2.put("null", null)
+      test("Pick a random branch using constants in configuration") {
+        val configuration = Configuration.Default.copy(
+          booleanGen = Gen.const(true),
+          doubleGen = Gen.const(12d),
+          stringGen = Gen.const("hello"),
+          intGen = Gen.const(8)
+        )
+        val expectedFoo = new RecordBuilder(fooBranch)
+          .set("boolean", true)
+          .set("int", 8)
+          .build()
 
-        recordsShouldMatch(gen(Parameters.default, secondSeed), expectedForSeed2, expectedSchema = barBranch)
-      },
-      test("generating a random record with changed config") {
-        val expectedWithOverrides = new GenericData.Record(expectedForSeed1, true)
-        expectedWithOverrides.put("boolean", false)
-        expectedWithOverrides.put("int", 23)
-
-        val newConfig = Configuration.Default.copy(booleanGen = Gen.const(false), intGen = Gen.posNum[Int])
-        val gen = genFromSchema(schema, configuration = newConfig)
-        recordsShouldMatch(gen(Parameters.default, firstSeed), expectedWithOverrides, expectedSchema = fooBranch)
+        val expectedBar = new RecordBuilder(barBranch)
+          .set("double", 12d)
+          .set("string", "hello")
+          .set("null", null)
+          .build()
+        forAll(genFromSchema(schema, configuration))(
+          r => recordsShouldMatch(Some(r), expectedFoo, expectedSchema = fooBranch).or(recordsShouldMatch(Some(r), expectedBar, expectedSchema = barBranch)))
       },
       suite("Invalid overrides",
         test("should not let you select a branch that doesn't exist in the union") {
@@ -69,27 +64,30 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
         test("selecting a specific union branch") {
           val overrides = selectNamedUnion("Bar")
 
-          val expectedUnionSelected = new GenericData.Record(barBranch)
-          expectedUnionSelected.put("double", 1.99638128080751E10)
-          expectedUnionSelected.put("string", "vzqzfoadmfdki9k1ofcrsjmvFuIJuqen")
-          expectedUnionSelected.put("null", null)
+          val configuration = Configuration.Default.copy(
+            doubleGen = Gen.const(12d),
+            stringGen = Gen.const("hello"),
+          )
 
-          val newConfig = Configuration.Default.copy(stringGen = Gen.alphaNumStr)
+          val expectedRecord = new RecordBuilder(barBranch)
+            .set("double", 12d)
+            .set("string", "hello")
+            .set("null", null)
+            .build()
 
-          val gen = genFromSchema(schema, configuration = newConfig, overrides = overrides)
-          recordsShouldMatch(gen(Parameters.default, firstSeed), expectedUnionSelected, expectedSchema = barBranch)
+          forAll(genFromSchema(schema, configuration, overrides))(r => recordsShouldMatch(Some(r), expectedRecord, expectedSchema = barBranch))
         },
         test("selecting and overriding a branch") {
           val overrides =
             selectNamedUnion("Bar", overrideKeys("double" -> constantOverride(1.0), "string" -> constantOverride("bar")))
 
-          val expectedUnionSelected = new GenericData.Record(barBranch)
-          expectedUnionSelected.put("double", 1.0)
-          expectedUnionSelected.put("string", "bar")
-          expectedUnionSelected.put("null", null)
+          val expectedUnionSelected = new RecordBuilder(barBranch)
+            .set("double", 1.0)
+            .set("string", "bar")
+            .set("null", null)
+            .build()
 
-          val gen = genFromSchema(schema, overrides = overrides)
-          recordsShouldMatch(gen(Parameters.default, firstSeed), expectedUnionSelected, expectedSchema = barBranch)
+          forAll(genFromSchema(schema, overrides = overrides))(r => recordsShouldMatch(Some(r), expectedUnionSelected, expectedSchema = barBranch))
         }
       )
     )

--- a/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
+++ b/src/test/scala/io/github/olib963/avrocheck/UnionSchemaTests.scala
@@ -46,7 +46,7 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
           .set("null", null)
           .build()
         forAll(genFromSchema(schema, configuration))(
-          r => recordsShouldMatch(Some(r), expectedFoo, expectedSchema = fooBranch).or(recordsShouldMatch(Some(r), expectedBar, expectedSchema = barBranch)))
+          r => recordsShouldMatch(r, expectedFoo, expectedSchema = fooBranch).or(recordsShouldMatch(r, expectedBar, expectedSchema = barBranch)))
       },
       suite("Invalid overrides",
         test("should not let you select a branch that doesn't exist in the union") {
@@ -73,7 +73,7 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
             .set("null", null)
             .build()
 
-          forAll(genFromSchema(schema, configuration, overrides))(r => recordsShouldMatch(Some(r), expectedRecord, expectedSchema = barBranch))
+          forAll(genFromSchema(schema, configuration, overrides))(r => recordsShouldMatch(r, expectedRecord, expectedSchema = barBranch))
         },
         test("selecting and overriding a branch") {
           val overrides =
@@ -85,7 +85,7 @@ object UnionSchemaTests extends SchemaGeneratorSuite with AllJavaTestSyntax with
             .set("null", null)
             .build()
 
-          forAll(genFromSchema(schema, overrides = overrides))(r => recordsShouldMatch(Some(r), expectedUnionSelected, expectedSchema = barBranch))
+          forAll(genFromSchema(schema, overrides = overrides))(r => recordsShouldMatch(r, expectedUnionSelected, expectedSchema = barBranch))
         }
       )
     )


### PR DESCRIPTION
Allow providing a custom generator to be passed as an override for a type. Type checking will be performed on the generator provided.

Also includes the first pass of test changes.